### PR TITLE
Fixing kisame's bunshin water prison

### DIFF
--- a/game/dota_addons/nwrrelaunch/scripts/npc/abilities/kisame/kisame_bunshin_water_prison.txt
+++ b/game/dota_addons/nwrrelaunch/scripts/npc/abilities/kisame/kisame_bunshin_water_prison.txt
@@ -1,31 +1,26 @@
-	
-    "DOTAAbilities"
-{
-    
-    
 "kisame_bunshin_water_prison"
 {
-
-
 	// General
 	//-------------------------------------------------------------------------------------------------------------
-	"BaseClass"					"ability_datadriven"
+	"BaseClass"					"ability_lua"
+	"ScriptFile"                "heroes/kisame/bunshin_water_prison.lua"
 	"AbilityBehavior"			"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELED"
 	"AbilityUnitTargetTeam"		"DOTA_UNIT_TARGET_TEAM_ENEMY"
 	"AbilityUnitTargetType"		"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+	"AbilityUnitDamageType"		"DAMAGE_TYPE_MAGICAL"	
 	"SpellImmunityType"			"SPELL_IMMUNITY_ENEMIES_NO"
 	"FightRecapLevel"			"1"
 	"AbilityTextureName"		"kisame_bunshin_water_prison"
 	
 	// Casting
 	//-------------------------------------------------------------------------------------------------------------
-	"AbilityCastRange"				"400"
+	"AbilityCastRange"				"150"
 	"AbilityCastPoint"				"0.3 0.3 0.3 0.3"
 
 	// Time		
 	//-------------------------------------------------------------------------------------------------------------
-	"AbilityChannelTime"			"1.25 1.5 1.75 2.00"
-	"AbilityCooldown"				"14.0"
+	"AbilityChannelTime"			"1.37 1.75 2.12 2.50"
+	"AbilityCooldown"				"16.0 14.0 12.0 10.0"
 
 	// Damage.
 	//-------------------------------------------------------------------------------------------------------------
@@ -42,96 +37,18 @@
 		"01"
 		{
 			"var_type"			"FIELD_FLOAT"
-			"channel_time"		"1.25 1.50 1.75 2.00"
+			"channel_time"		"1.37 1.75 2.12 2.50"
+		}
+		"02"
+		{
+			"var_type"			"FIELD_FLOAT"
+			"range"		"150"
 		}
 	}
 
 	"precache"
 	{
 		"particle"	"particles/units/heroes/kisame/bunshin_prison_new.vpcf"
-	 	"soundfile"  "soundevents/kisame_bunshin_water_prison.vsndevts"
+		"soundfile" "soundevents/kisame_bunshin_water_prison.vsndevts"
 	}
-
-	"OnSpellStart"
-	{
-
-		"RunScript"
-			{
-				"ScriptFile"	"heroes/kisame/bunshin_water_prison.lua"
-				"Function"		"emitSoundOnTarget"
-				"target"		"TARGET"
-			}
-
-		"ApplyModifier"
-		{
-			"ModifierName"	"modifier_bunshin_water_prison_hold"
-			"Target" 		"TARGET"
-			"Duration"		"%channel_time"
-		}
-	}
-
-	"OnChannelFinish"
-	{
-		"RemoveModifier"
-		{
-			"ModifierName"	"modifier_bunshin_water_prison_hold"
-			"Target" 		"TARGET"
-		}
-	
-	}
-
-	"OnChannelInterrupted"
-	{
-		"RemoveModifier"
-		{
-			"ModifierName"	"modifier_bunshin_water_prison_hold"
-			"Target" 		"TARGET"
-		}
-	
-	}
-
-	"Modifiers"
-	{
-		"modifier_bunshin_water_prison_hold"
-		{
-			"IsDebuff"			"1"
-	
-			"States"
-			{
-				"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
-			}
-
-	
-			"OverrideAnimation"     "ACT_DOTA_DISABLED"
-
-			"OnCreated"
-			{
-				"RunScript"
-				{
-					"ScriptFile"	"heroes/kisame/bunshin_water_prison.lua"
-					"Function" 		"emitSoundOnTarget"
-				}
-				
-				"RunScript"
-				{
-					"ScriptFile"	"heroes/kisame/bunshin_water_prison.lua"
-					"Function"		"applyEffect"
-				}
-			}
-
-			"ThinkInterval"  "0.1"
-			"OnIntervalThink"
-			{
-				"RunScript"
-				{
-					"ScriptFile"	"heroes/kisame/bunshin_water_prison.lua"
-					"Function"		"stopChannelOnDead"
-				}
-			}
-		}
-	}
-
-}
-
-
 }

--- a/game/dota_addons/nwrrelaunch/scripts/vscripts/heroes/kisame/bunshin_water_prison.lua
+++ b/game/dota_addons/nwrrelaunch/scripts/vscripts/heroes/kisame/bunshin_water_prison.lua
@@ -1,26 +1,69 @@
-function stopChannelOnDead( keys )
-	if keys.caster == nil then
-		keys.target:RemoveModifierByName("modifier_bunshin_water_prison_hold")
-		--ParticleManager:DestroyParticle(keys.ability.waterPrison_particle, true)
-                --ParticleManager:ReleaseParticleIndex(keys.ability.waterPrison_particle)
-	end
+kisame_bunshin_water_prison = class({})
+
+function kisame_bunshin_water_prison:Precache( context )
+PrecacheResource( "soundfile", "soundevents/kisame_bunshin_water_prison.vsndevts", context )
+PrecacheResource( "particle", "particles/units/heroes/kisame/bunshin_prison_new.vpcf", context )
 end
 
-function applyEffect(keys)
-    local duration = keys.ability:GetSpecialValueFor("channel_time")
-    
-    keys.ability.waterPrison_particle = ParticleManager:CreateParticle("particles/units/heroes/kisame/bunshin_prison_new.vpcf", PATTACH_ABSORIGIN, keys.target)
-    ParticleManager:SetParticleControl(keys.ability.waterPrison_particle, 0, keys.target:GetAbsOrigin())
-    ParticleManager:SetParticleControl(keys.ability.waterPrison_particle, 1, keys.target:GetAbsOrigin())
-    ParticleManager:SetParticleControl(keys.ability.waterPrison_particle, 2, Vector(2, 1, 10))
-    ParticleManager:SetParticleControl(keys.ability.waterPrison_particle, 3, keys.target:GetAbsOrigin())
+function kisame_bunshin_water_prison:GetCooldown(iLevel)
+return self.BaseClass.GetCooldown(self, iLevel)
+end
+
+function kisame_bunshin_water_prison:GetCastRange(location, target)
+return self:GetSpecialValueFor("range")
+end
+
+function kisame_bunshin_water_prison:GetChannelTime()
+return self:GetSpecialValueFor("channel_time")
+end
+
+function kisame_bunshin_water_prison:OnSpellStart()
+    -- load data
+    local duration = self:GetSpecialValueFor("channel_time")
+	self.target = self:GetCursorTarget()
 	
-	Timers:CreateTimer(duration, function ()
-	    ParticleManager:DestroyParticle(keys.ability.waterPrison_particle, true)
-        ParticleManager:ReleaseParticleIndex(keys.ability.waterPrison_particle)
-	end)
+	self:GetCursorTarget():AddNewModifier(
+        self:GetCaster(), -- player source
+        self, -- ability source
+        "modifier_stunned", -- modifier name
+        { duration = duration } -- kv
+    )
+    
+    local sound_cast = "kisame_bunshin_water_prison"
+    EmitSoundOn(sound_cast, self:GetCaster())
+    
+    self:GetCursorTarget():StartGestureWithPlaybackRate(ACT_DOTA_DISABLED, 1)
+    
+    self.waterPrison_particle = ParticleManager:CreateParticle("particles/units/heroes/kisame/bunshin_prison_new.vpcf", PATTACH_ABSORIGIN, self:GetCursorTarget())
+    ParticleManager:SetParticleControl(self.waterPrison_particle, 0, self:GetCursorTarget():GetAbsOrigin())
+    ParticleManager:SetParticleControl(self.waterPrison_particle, 1, self:GetCursorTarget():GetAbsOrigin())
+    ParticleManager:SetParticleControl(self.waterPrison_particle, 2, Vector(2, 10, 10))
+    ParticleManager:SetParticleControl(self.waterPrison_particle, 3, self:GetCursorTarget():GetAbsOrigin())
 end
 
-function emitSoundOnTarget( keys )
-	keys.target:EmitSound("kisame_bunshin_water_prison")
+function kisame_bunshin_water_prison:OnChannelFinish(bInterrupted)
+    local target = self.target
+    local caster = self.caster
+    
+    if bInterrupted then
+        target:RemoveModifierByName("modifier_stunned")
+        
+        local sound_cast = "kisame_bunshin_water_prison"
+        StopSoundOn(sound_cast, caster)
+        
+        target:RemoveGesture(ACT_DOTA_DISABLED)
+        
+        ParticleManager:DestroyParticle(self.waterPrison_particle, true)
+        ParticleManager:ReleaseParticleIndex(self.waterPrison_particle)
+    end
+    
+    target:RemoveModifierByName("modifier_stunned")
+    
+    local sound_cast = "kisame_bunshin_water_prison"
+    StopSoundOn(sound_cast, caster)
+    
+    target:RemoveGesture(ACT_DOTA_DISABLED)
+    
+    ParticleManager:DestroyParticle(self.waterPrison_particle, true)
+    ParticleManager:ReleaseParticleIndex(self.waterPrison_particle)
 end

--- a/game/dota_addons/nwrrelaunch/scripts/vscripts/heroes/kisame/mizu_bunshin_no_jutsu.lua
+++ b/game/dota_addons/nwrrelaunch/scripts/vscripts/heroes/kisame/mizu_bunshin_no_jutsu.lua
@@ -186,7 +186,11 @@ function draw( keys )
 end
 
 function RemoveBunshin( keys )
-  keys.target:Destroy()
+  keys.target:ForceKill(false)
+    
+    Timers:CreateTimer(0.1, function()
+        keys.target:Destroy()
+    end)
 end
 
 


### PR DESCRIPTION
So, if you try to use water prison now, when the remaining life time of the clones is less than the duration of the ability, you'll see that the ability doesn't end correctly - it keeps working until the timer in the "applyEffect" function is triggered. I fixed this problem by moving the script to lua, now the ability ends immediately if the clones disappear (die)